### PR TITLE
LCD overflow bug and audio demo bug fixes

### DIFF
--- a/Demos/ACLDemo.X/lcd.c
+++ b/Demos/ACLDemo.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position

--- a/Demos/AICDemo.X/lcd.c
+++ b/Demos/AICDemo.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position

--- a/Demos/AUDIODemo.X/audio.c
+++ b/Demos/AUDIODemo.X/audio.c
@@ -317,6 +317,7 @@ void AUDIO_Close()
 {
         T3CONbits.ON = 0;       // turn off Timer3
         OC1CONbits.ON = 0;      // Turn off OC1
+        bAudioMode = -1;        // reset bAudioMode parameter
         
 }
 

--- a/Demos/AUDIODemo.X/lcd.c
+++ b/Demos/AUDIODemo.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position

--- a/Demos/BasicIODemo.X/lcd.c
+++ b/Demos/BasicIODemo.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position

--- a/Demos/BasysMX3_User_Demo.X/audio.c
+++ b/Demos/BasysMX3_User_Demo.X/audio.c
@@ -317,6 +317,7 @@ void AUDIO_Close()
 {
         T3CONbits.ON = 0;       // turn off Timer3
         OC1CONbits.ON = 0;      // Turn off OC1
+        bAudioMode = -1;        // reset bAudioMode parameter
         
 }
 

--- a/Demos/BasysMX3_User_Demo.X/lcd.c
+++ b/Demos/BasysMX3_User_Demo.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position

--- a/Demos/MOTDemo.X/lcd.c
+++ b/Demos/MOTDemo.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position

--- a/Demos/SPIFLASHDemo.X/lcd.c
+++ b/Demos/SPIFLASHDemo.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position

--- a/Demos/SPIJADemo.X/lcd.c
+++ b/Demos/SPIJADemo.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position

--- a/Demos/SSDDemo.X/lcd.c
+++ b/Demos/SSDDemo.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position

--- a/Demos/UARTDemo.X/lcd.c
+++ b/Demos/UARTDemo.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position

--- a/LibPack/LibPack.X/audio.c
+++ b/LibPack/LibPack.X/audio.c
@@ -317,6 +317,7 @@ void AUDIO_Close()
 {
         T3CONbits.ON = 0;       // turn off Timer3
         OC1CONbits.ON = 0;      // Turn off OC1
+        bAudioMode = -1;        // reset bAudioMode parameter
         
 }
 

--- a/LibPack/LibPack.X/lcd.c
+++ b/LibPack/LibPack.X/lcd.c
@@ -431,19 +431,19 @@ void LCD_CursorShift(unsigned char fRight)
 **	Description:
 **		Displays the specified string at the specified position on the specified line. 
 **		It sets the corresponding write position and then writes data bytes when the device is ready.
-**      Strings longer than 40 characters are trimmed. 
+**      Strings longer than 32 characters are trimmed. 
 **      It is possible that not all the characters will be visualized, as the display only visualizes 16 characters for one line.
 **      
 **          
 */
 void LCD_WriteStringAtPos(char *szLn, unsigned char idxLine, unsigned char idxPos)
 {
-	// crop string to 0x27 chars
+	// crop string to 0x1F chars
 	int len = strlen(szLn);
-	if(len > 0x27)
+	if(len > 0x1F)
 	{
-        szLn[0x27] = 0; // trim the string so it contains 40 characters 
-		len = 0x27;
+        szLn[0x1F] = 0; // trim the string so it contains 32 characters 
+		len = 0x1F;
 	}
 
 	// Set write position


### PR DESCRIPTION
Changed LCD.c's to limit the number of characters shown on the display from 40 to 32. This was creating a bug in the OOB where the LCD would display the incorrect combinations of LCD string values. 
40 characters can be used with the KS0066 display controller but is only supported when 2 displays are used in series with one another, which I doubt will be a primary use case for the Basys MX3.
Also added a line in the audio_Close function in the audio.c to allow for users to disable and re-enable the same mode repeatedly without being forced to switch audio modes.